### PR TITLE
Use query and hash in redirects

### DIFF
--- a/dslc-io.Rproj
+++ b/dslc-io.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: d6acfb64-9470-45f8-94a9-952118c0582b
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/redirect-404.js
+++ b/redirect-404.js
@@ -1,7 +1,13 @@
 function handlePageNotFound() {
   try {
-    const target = window.location.pathname.replace(/^\//, '').replace(/\/$/, '');
+    const url = new URL(window.location.href);
+    const target = url.pathname.replace(/^//, '').replace(//$/, '');
+    const query = url.search; // Includes the leading '?' if there are query parameters
+    const hash = url.hash; // Includes the leading '#' if there is a hash
+
     console.log("Handling page not found for target:", target);
+    console.log("Query parameters:", query);
+    console.log("Hash:", hash);
 
     // Exit early if no target
     if (!target) {

--- a/redirect.js
+++ b/redirect.js
@@ -2,7 +2,7 @@
 const parsedTSVData = {};
 
 // General function to handle redirection
-async function handleRedirection(target, TSV_URL, fallbackPath = null) {
+async function handleRedirection(target, TSV_URL, fallbackPath = null, query = null, hash = null) {
   try {
     console.log("Handling redirection for target:", target);
     if (!target || !TSV_URL) {
@@ -23,8 +23,18 @@ async function handleRedirection(target, TSV_URL, fallbackPath = null) {
 
     const redirectMap = parsedTSVData[TSV_URL];
     if (redirectMap[target]) {
-      console.log("Redirecting to URL:", redirectMap[target]);
-      window.location.href = redirectMap[target];
+      const redirectURL = new URL(redirectMap[target], window.location.origin);
+
+      if (query) {
+        redirectURL.search = query;
+      }
+
+      if (hash) {
+        redirectURL.hash = hash;
+      }
+
+      console.log("Redirecting to URL:", redirectURL.href);
+      window.location.href = redirectURL.href;
       return true;
     } else {
       console.warn("Target not found in redirect map:", target);
@@ -34,3 +44,4 @@ async function handleRedirection(target, TSV_URL, fallbackPath = null) {
   }
   return false; // Redirection failed or target not found
 }
+


### PR DESCRIPTION
Oops, bookclubber has been semi-broken for a while now! I wasn't forwarding the `?` portion of URLs through to bookclubber, so users always had to choose their book.